### PR TITLE
Add EF Core data access layer

### DIFF
--- a/ByBitIntegration.sln
+++ b/ByBitIntegration.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyProject.Domain", "MyProje
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bybit.Tests", "Bybit.Tests\Bybit.Tests.csproj", "{C68BE130-ABE4-49D7-A12B-B3AF611ECE36}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyProject.DataAccess", "MyProject.DataAccess\MyProject.DataAccess.csproj", "{E34820E0-CECF-4581-9AD0-F33FC04B3017}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -30,5 +32,9 @@ Global
 		{C68BE130-ABE4-49D7-A12B-B3AF611ECE36}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C68BE130-ABE4-49D7-A12B-B3AF611ECE36}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C68BE130-ABE4-49D7-A12B-B3AF611ECE36}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E34820E0-CECF-4581-9AD0-F33FC04B3017}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E34820E0-CECF-4581-9AD0-F33FC04B3017}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E34820E0-CECF-4581-9AD0-F33FC04B3017}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E34820E0-CECF-4581-9AD0-F33FC04B3017}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/Bybit.Tests/Bybit.Tests.csproj
+++ b/Bybit.Tests/Bybit.Tests.csproj
@@ -18,10 +18,12 @@
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="../ByBit/ByBit.csproj" />
+    <ProjectReference Include="../MyProject.DataAccess/MyProject.DataAccess.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Bybit.Tests/DataAccess/KlineRepositoryTests.cs
+++ b/Bybit.Tests/DataAccess/KlineRepositoryTests.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore;
+using MyProject.DataAccess;
+using MyProject.DataAccess.Entities;
+using MyProject.DataAccess.Repositories;
+using NUnit.Framework;
+
+namespace ByBit.Tests.DataAccess;
+
+[TestFixture]
+public class KlineRepositoryTests
+{
+    private KlineDbContext _context = null!;
+    private KlineRepository _repository = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var options = new DbContextOptionsBuilder<KlineDbContext>()
+            .UseInMemoryDatabase("klines")
+            .Options;
+        _context = new KlineDbContext(options);
+        _repository = new KlineRepository(_context);
+    }
+
+    [Test]
+    public async Task SaveAsync_SavesRecords()
+    {
+        var klines = new[]
+        {
+            new KlineEntity { Symbol = "BTCUSDT", Interval = "1m", StartTime = 1, Open = 1, High = 1, Low = 1, Close = 1, Volume = 1, Turnover = 1 },
+        };
+
+        await _repository.SaveAsync(klines);
+
+        var saved = await _repository.GetAsync("BTCUSDT", "1m");
+        Assert.That(saved, Has.Count.EqualTo(1));
+    }
+}

--- a/MyProject.DataAccess/Entities/KlineEntity.cs
+++ b/MyProject.DataAccess/Entities/KlineEntity.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace MyProject.DataAccess.Entities;
+
+[Table("Klines")]
+public class KlineEntity
+{
+    [Key]
+    public int Id { get; set; }
+
+    [Required]
+    public string Symbol { get; set; } = string.Empty;
+
+    [Required]
+    public string Interval { get; set; } = string.Empty;
+
+    public long StartTime { get; set; }
+    public decimal Open { get; set; }
+    public decimal High { get; set; }
+    public decimal Low { get; set; }
+    public decimal Close { get; set; }
+    public decimal Volume { get; set; }
+    public decimal Turnover { get; set; }
+}

--- a/MyProject.DataAccess/KlineDbContext.cs
+++ b/MyProject.DataAccess/KlineDbContext.cs
@@ -1,0 +1,20 @@
+using Microsoft.EntityFrameworkCore;
+using MyProject.DataAccess.Entities;
+
+namespace MyProject.DataAccess;
+
+public class KlineDbContext : DbContext
+{
+    public KlineDbContext(DbContextOptions<KlineDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<KlineEntity> Klines => Set<KlineEntity>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<KlineEntity>()
+            .HasIndex(k => new { k.Symbol, k.Interval, k.StartTime })
+            .IsUnique();
+    }
+}

--- a/MyProject.DataAccess/Migrations/0001_InitialCreate.cs
+++ b/MyProject.DataAccess/Migrations/0001_InitialCreate.cs
@@ -1,0 +1,43 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MyProject.DataAccess.Migrations;
+
+public partial class InitialCreate : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "Klines",
+            columns: table => new
+            {
+                Id = table.Column<int>(nullable: false)
+                    .Annotation("Sqlite:Autoincrement", true),
+                Symbol = table.Column<string>(nullable: false),
+                Interval = table.Column<string>(nullable: false),
+                StartTime = table.Column<long>(nullable: false),
+                Open = table.Column<decimal>(nullable: false),
+                High = table.Column<decimal>(nullable: false),
+                Low = table.Column<decimal>(nullable: false),
+                Close = table.Column<decimal>(nullable: false),
+                Volume = table.Column<decimal>(nullable: false),
+                Turnover = table.Column<decimal>(nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_Klines", x => x.Id);
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Klines_Symbol_Interval_StartTime",
+            table: "Klines",
+            columns: new[] { "Symbol", "Interval", "StartTime" },
+            unique: true);
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(name: "Klines");
+    }
+}

--- a/MyProject.DataAccess/Migrations/KlineDbContextModelSnapshot.cs
+++ b/MyProject.DataAccess/Migrations/KlineDbContextModelSnapshot.cs
@@ -1,0 +1,60 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using MyProject.DataAccess;
+using MyProject.DataAccess.Entities;
+
+#nullable disable
+
+namespace MyProject.DataAccess.Migrations;
+
+[DbContext(typeof(KlineDbContext))]
+partial class KlineDbContextModelSnapshot : ModelSnapshot
+{
+    protected override void BuildModel(ModelBuilder modelBuilder)
+    {
+        modelBuilder.HasAnnotation("ProductVersion", "8.0.0");
+
+        modelBuilder.Entity<KlineEntity>(b =>
+        {
+            b.Property<int>("Id")
+                .ValueGeneratedOnAdd()
+                .HasColumnType("INTEGER");
+
+            b.Property<decimal>("Close")
+                .HasColumnType("TEXT");
+
+            b.Property<decimal>("High")
+                .HasColumnType("TEXT");
+
+            b.Property<decimal>("Low")
+                .HasColumnType("TEXT");
+
+            b.Property<decimal>("Open")
+                .HasColumnType("TEXT");
+
+            b.Property<long>("StartTime")
+                .HasColumnType("INTEGER");
+
+            b.Property<string>("Symbol")
+                .IsRequired()
+                .HasColumnType("TEXT");
+
+            b.Property<string>("Interval")
+                .IsRequired()
+                .HasColumnType("TEXT");
+
+            b.Property<decimal>("Turnover")
+                .HasColumnType("TEXT");
+
+            b.Property<decimal>("Volume")
+                .HasColumnType("TEXT");
+
+            b.HasKey("Id");
+
+            b.HasIndex("Symbol", "Interval", "StartTime")
+                .IsUnique();
+
+            b.ToTable("Klines");
+        });
+    }
+}

--- a/MyProject.DataAccess/MyProject.DataAccess.csproj
+++ b/MyProject.DataAccess/MyProject.DataAccess.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../MyProject.Domain/MyProject.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/MyProject.DataAccess/Repositories/IKlineRepository.cs
+++ b/MyProject.DataAccess/Repositories/IKlineRepository.cs
@@ -1,0 +1,9 @@
+using MyProject.DataAccess.Entities;
+
+namespace MyProject.DataAccess.Repositories;
+
+public interface IKlineRepository
+{
+    Task SaveAsync(IEnumerable<KlineEntity> klines, CancellationToken ct = default);
+    Task<List<KlineEntity>> GetAsync(string symbol, string interval, CancellationToken ct = default);
+}

--- a/MyProject.DataAccess/Repositories/KlineRepository.cs
+++ b/MyProject.DataAccess/Repositories/KlineRepository.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore;
+using MyProject.DataAccess.Entities;
+
+namespace MyProject.DataAccess.Repositories;
+
+public class KlineRepository : IKlineRepository
+{
+    private readonly KlineDbContext _context;
+
+    public KlineRepository(KlineDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task SaveAsync(IEnumerable<KlineEntity> klines, CancellationToken ct = default)
+    {
+        foreach (var kline in klines)
+        {
+            var exists = await _context.Klines.AnyAsync(k => k.Symbol == kline.Symbol &&
+                                                           k.Interval == kline.Interval &&
+                                                           k.StartTime == kline.StartTime, ct);
+            if (!exists)
+            {
+                _context.Klines.Add(kline);
+            }
+        }
+
+        await _context.SaveChangesAsync(ct);
+    }
+
+    public async Task<List<KlineEntity>> GetAsync(string symbol, string interval, CancellationToken ct = default)
+    {
+        return await _context.Klines
+            .Where(k => k.Symbol == symbol && k.Interval == interval)
+            .OrderBy(k => k.StartTime)
+            .ToListAsync(ct);
+    }
+}

--- a/docs/ByBit/README.md
+++ b/docs/ByBit/README.md
@@ -5,6 +5,7 @@ This solution provides a lightweight integration layer over the official [`bybit
 The project is organised as a set of services that can be registered via dependency injection. All examples use the Bybit testnet URL by default.
 
 ## Features
+- Persist klines using Entity Framework Core (see `MyProject.DataAccess`)
 - Retrieve market klines (candlesticks) for inverse/USDT perpetual symbols
 - Place spot market orders
 - Query unified account balances

--- a/docs/MyProject.DataAccess/README.md
+++ b/docs/MyProject.DataAccess/README.md
@@ -1,0 +1,14 @@
+# MyProject.DataAccess
+
+This library contains the Entity Framework Core setup used to persist Bybit kline data.
+It defines the `KlineDbContext`, entity models and a simple repository.
+
+## Usage
+1. Register `KlineDbContext` with your service container:
+   ```csharp
+   services.AddDbContext<KlineDbContext>(o => o.UseSqlite("Data Source=klines.db"));
+   services.AddScoped<IKlineRepository, KlineRepository>();
+   ```
+2. Apply migrations and use `IKlineRepository` to store or query klines.
+
+The context contains a single `Klines` table indexed by symbol, interval and start time.


### PR DESCRIPTION
## Summary
- add new `MyProject.DataAccess` project using EF Core
- provide `KlineDbContext` and repository for persisting klines
- include initial migration and entity model
- document data access usage and mention it in ByBit README
- extend tests with simple repository test

## Testing
- `dotnet test` *(fails: failed to restore packages)*